### PR TITLE
Fix imports for Cordova 9

### DIFF
--- a/hooks/addTodayWidgetToProject.js
+++ b/hooks/addTodayWidgetToProject.js
@@ -1,8 +1,11 @@
 // @ts-check
 
+var elementTree = require('elementtree');
 var fs = require('fs');
 var path = require('path');
 var plist = require('plist');
+var Q = require('q');
+var xcode = require('xcode');
 
 function log(logString, type) {
   var prefix;
@@ -69,8 +72,6 @@ log(
 );
 
 module.exports = function (context) {
-  var xcode = context.requireCordovaModule('xcode');
-  var Q = context.requireCordovaModule('q');
   var deferral = new Q.defer();
 
   if (context.opts.cordova.platforms.indexOf('ios') < 0) {
@@ -92,7 +93,6 @@ module.exports = function (context) {
   }
 
   // Get the bundle-id from config.xml
-  var elementTree = context.requireCordovaModule('elementtree');
   var etree = elementTree.parse(contents);
   var bundleId = etree.getroot().get('id');
   log('Bundle id of your host app: ' + bundleId, 'info');

--- a/hooks/copyExtensionFolderToIosProjectFolder.js
+++ b/hooks/copyExtensionFolderToIosProjectFolder.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var Q = require('q');
 
 function log(logString, type) {
   var prefix;
@@ -94,7 +95,6 @@ function getCordovaParameter(variableName, contents) {
 }
 
 module.exports = function(context) {
-  var Q = context.requireCordovaModule('q');
   var deferral = new Q.defer();
 
   var contents = fs.readFileSync(

--- a/hooks/fixAppEntitlements.js
+++ b/hooks/fixAppEntitlements.js
@@ -1,8 +1,11 @@
 // @ts-check
 
+var elementTree = require('elementtree');
 var fs = require('fs');
 var path = require('path');
 var plist = require('plist');
+var Q = require('q');
+var xcode = require('xcode');
 
 function log(logString, type) {
   var prefix;
@@ -57,8 +60,6 @@ log(
 );
 
 module.exports = function (context) {
-  var xcode = context.requireCordovaModule('xcode');
-  var Q = context.requireCordovaModule('q');
   var deferral = new Q.defer();
 
   if (context.opts.cordova.platforms.indexOf('ios') < 0) {
@@ -75,7 +76,6 @@ module.exports = function (context) {
   }
 
   // Get the bundle-id from config.xml
-  var elementTree = context.requireCordovaModule('elementtree');
   var etree = elementTree.parse(contents);
   var bundleId = etree.getroot().get('id');
 

--- a/hooks/prerequisites.js
+++ b/hooks/prerequisites.js
@@ -1,8 +1,10 @@
-module.exports = function (context) {
-	var child_process = context.requireCordovaModule('child_process'),
-         deferral = context.requireCordovaModule('q').defer();
+var child_process = require('child_process');
+var Q = require('q');
 
-child_process.exec('npm install', {cwd:__dirname},
+module.exports = function (context) {
+	var deferral = Q.defer();
+
+	child_process.exec('npm install', {cwd:__dirname},
 		function (error) {
 			if (error !== null) {
 			  console.log('exec error: ' + error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "cordova-plugin-today-widget",
   "version": "1.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "ansi-escapes": {
       "version": "1.4.0",
@@ -31,7 +32,10 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -40,32 +44,53 @@
       "dev": true
     },
     "base64-js": {
-      "version": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz",
-      "integrity": "sha1-1kAMrBxMZgl22Q0HoENR2JOV9eg="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+      "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE="
     },
     "big-integer": {
-      "version": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.23.tgz",
-      "integrity": "sha1-6F1QgiDHTj9DpM5y7tUfPaTblNE="
+      "version": "1.6.44",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.44.tgz",
+      "integrity": "sha512-7MzElZPTyJ2fNvBkPxtFQ2fWIkVmuzw41+BZHSzpEq3ymB2MfeKp1+yXl/tS75xCx+WnyV+yb0kp+K1C3UNwmQ=="
     },
     "bplist-creator": {
-      "version": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
-      "integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU="
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
+      "integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
+      "requires": {
+        "stream-buffers": "~2.2.0"
+      }
     },
     "bplist-parser": {
-      "version": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
-      "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+      "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+      "requires": {
+        "big-integer": "^1.6.7"
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
     },
     "ci-info": {
       "version": "1.0.0",
@@ -77,7 +102,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^1.0.1"
+      }
     },
     "cli-spinners": {
       "version": "0.1.2",
@@ -89,7 +117,11 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
       "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "^1.0.1"
+      }
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -101,7 +133,10 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -113,13 +148,28 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
       "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "js-yaml": "^3.4.3",
+        "minimist": "^1.2.0",
+        "object-assign": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "parse-json": "^2.2.0",
+        "pinkie-promise": "^2.0.0",
+        "require-from-string": "^1.1.0"
+      }
     },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
     },
     "date-fns": {
       "version": "1.28.5",
@@ -133,11 +183,22 @@
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
+    "elementtree": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
+      "integrity": "sha1-mskb5uUvtuYkTE5UpKw+2K6OKcA=",
+      "requires": {
+        "sax": "1.1.4"
+      }
+    },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -155,7 +216,16 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -167,15 +237,28 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      }
     },
     "file-match": {
-      "version": "https://registry.npmjs.org/file-match/-/file-match-1.0.2.tgz",
-      "integrity": "sha1-ycrSZdLIrfOoFHWw30dYWQafrvc="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/file-match/-/file-match-1.0.2.tgz",
+      "integrity": "sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=",
+      "requires": {
+        "utils-extend": "^1.0.6"
+      }
     },
     "file-system": {
-      "version": "https://registry.npmjs.org/file-system/-/file-system-2.2.2.tgz",
-      "integrity": "sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/file-system/-/file-system-2.2.2.tgz",
+      "integrity": "sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=",
+      "requires": {
+        "file-match": "^1.0.1",
+        "utils-extend": "^1.0.4"
+      }
     },
     "find-parent-dir": {
       "version": "0.3.0",
@@ -205,22 +288,35 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
     },
     "husky": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/husky/-/husky-0.13.4.tgz",
       "integrity": "sha1-SHhcUCjeNFKlHEjBLE+UshJKFAc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "find-parent-dir": "^0.3.0",
+        "is-ci": "^1.0.9",
+        "normalize-path": "^1.0.0"
+      }
     },
     "indent-string": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
     },
     "inherits": {
-      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
       "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
     },
     "is-arrayish": {
@@ -233,19 +329,28 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ci-info": "^1.0.0"
+      }
     },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
     },
     "is-promise": {
       "version": "2.1.0",
@@ -269,19 +374,52 @@
       "version": "3.8.4",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
       "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^3.1.1"
+      }
     },
     "lint-staged": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-3.6.1.tgz",
       "integrity": "sha1-JEI8i3vZnZbhWs0ayMs5KnjlhYI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "app-root-path": "^2.0.0",
+        "cosmiconfig": "^1.1.0",
+        "execa": "^0.7.0",
+        "listr": "^0.12.0",
+        "lodash.chunk": "^4.2.0",
+        "minimatch": "^3.0.0",
+        "npm-which": "^3.0.1",
+        "p-map": "^1.1.1",
+        "staged-git-files": "0.0.4"
+      }
     },
     "listr": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
       "integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "figures": "^1.7.0",
+        "indent-string": "^2.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.2.0",
+        "listr-verbose-renderer": "^0.4.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^1.0.2",
+        "ora": "^0.2.3",
+        "p-map": "^1.1.1",
+        "rxjs": "^5.0.0-beta.11",
+        "stream-to-observable": "^0.1.0",
+        "strip-ansi": "^3.0.1"
+      }
     },
     "listr-silent-renderer": {
       "version": "1.1.1",
@@ -294,6 +432,16 @@
       "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
       "integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
       "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^1.0.2",
+        "strip-ansi": "^3.0.1"
+      },
       "dependencies": {
         "indent-string": {
           "version": "3.1.0",
@@ -307,7 +455,13 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz",
       "integrity": "sha1-RNwBuww0oDxXIVTU0Izemx3FYg8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-cursor": "^1.0.2",
+        "date-fns": "^1.27.2",
+        "figures": "^1.7.0"
+      }
     },
     "lodash.chunk": {
       "version": "4.2.0",
@@ -319,25 +473,39 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0"
+      }
     },
     "log-update": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^1.0.0",
+        "cli-cursor": "^1.0.2"
+      }
     },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -355,19 +523,30 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
       "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "which": "^1.2.10"
+      }
     },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
     },
     "npm-which": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commander": "^2.9.0",
+        "npm-path": "^2.0.2",
+        "which": "^1.2.10"
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -391,7 +570,13 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "cli-cursor": "^1.0.2",
+        "cli-spinners": "^0.1.2",
+        "object-assign": "^4.0.1"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -415,21 +600,25 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
     },
     "path": {
-      "version": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8="
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
     },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
-    },
-    "pegjs": {
-      "version": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
-      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -441,11 +630,20 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
     },
     "plist": {
-      "version": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz",
-      "integrity": "sha1-CjLKlIGxw2TpLhjcVch23p0B2os="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
+      "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+      "requires": {
+        "base64-js": "1.2.0",
+        "xmlbuilder": "8.2.2",
+        "xmldom": "0.1.x"
+      }
     },
     "prettier": {
       "version": "1.4.4",
@@ -454,7 +652,8 @@
       "dev": true
     },
     "process": {
-      "version": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "pseudomap": {
@@ -463,11 +662,19 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
     },
     "require-from-string": {
       "version": "1.2.1",
@@ -479,19 +686,34 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      }
     },
     "rxjs": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.1.tgz",
       "integrity": "sha1-ti91fyeURdJloYpY+wpw3JDpFiY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "symbol-observable": "^1.0.1"
+      }
+    },
+    "sax": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+      "integrity": "sha1-dLbTPJrh4AFRDxeakRaFiPGu2qk="
     },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -506,8 +728,36 @@
       "dev": true
     },
     "simple-plist": {
-      "version": "https://registry.npmjs.org/simple-plist/-/simple-plist-0.2.1.tgz",
-      "integrity": "sha1-cXZts1IyaSjPOoByQrp2IyJjZyM="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.0.0.tgz",
+      "integrity": "sha512-043L2rO80LVF7zfZ+fqhsEkoJFvW8o59rt/l4ctx1TJWoTx7/jkiS1R5TatD15Z1oYnuLJytzE7gcnnBuIPL2g==",
+      "requires": {
+        "bplist-creator": "0.0.7",
+        "bplist-parser": "0.1.1",
+        "plist": "^3.0.1"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+          "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+        },
+        "plist": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
+          "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+          "requires": {
+            "base64-js": "^1.2.3",
+            "xmlbuilder": "^9.0.7",
+            "xmldom": "0.1.x"
+          }
+        },
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        }
+      }
     },
     "slice-ansi": {
       "version": "0.0.4",
@@ -528,7 +778,8 @@
       "dev": true
     },
     "stream-buffers": {
-      "version": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
     },
     "stream-to-observable": {
@@ -541,13 +792,21 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -568,33 +827,48 @@
       "dev": true
     },
     "util": {
-      "version": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk="
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "requires": {
+        "inherits": "2.0.1"
+      }
     },
     "utils-extend": {
-      "version": "https://registry.npmjs.org/utils-extend/-/utils-extend-1.0.8.tgz",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/utils-extend/-/utils-extend-1.0.8.tgz",
       "integrity": "sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8="
     },
     "uuid": {
-      "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "which": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "xcode": {
-      "version": "git+https://github.com/apache/cordova-node-xcode.git#322f304e1aac853867136d866087da29e04a54b2",
-      "integrity": "sha1-kEUjuipU+41rs12gbYCUoWNLMY4="
+      "version": "git+https://github.com/apache/cordova-node-xcode.git#b81970519188e4bac022f04c86a44f2437c4981e",
+      "from": "git+https://github.com/apache/cordova-node-xcode.git",
+      "requires": {
+        "simple-plist": "^1.0.0",
+        "uuid": "^3.3.2"
+      }
     },
     "xmlbuilder": {
-      "version": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
       "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
     },
     "xmldom": {
-      "version": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
   },
   "homepage": "https://github.com/DavidStrausz/cordova-plugin-today-widget",
   "dependencies": {
+    "elementtree": "^0.1.7",
     "file-system": "^2.2.2",
     "path": "^0.12.7",
     "plist": "^2.1.0",
+    "q": "^1.5.1",
     "xcode": "git+https://github.com/apache/cordova-node-xcode.git"
   },
   "devDependencies": {


### PR DESCRIPTION
Cordova 9 removed support for importing non-Cordova modules using `requireCordovaModule` (see https://github.com/apache/cordova-lib/issues/689), breaking this plugin. This PR adds those modules as normal dependencies instead.