### PR TITLE
Add Swift version as configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This plugin extends your existing xcode project by parsing and modifying the pro
 |WIDGET_NAME| <Name of main project> Widget | Name of your widget |
 |WIDGET_BUNDLE_SUFFIX| widget | The last part of the widget bundle id |
 |ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES| YES | You might have to turn this off (change to NO) if you use other swift based plugins (such as cordova-plugin-geofence) |
+|SWIFT_VERSION| '3.0' | The version of Swift that your widget uses |
 
 This can be done either manually in the config.xml after installing the plugin, or be done through the CLI.
 
@@ -81,5 +82,5 @@ To keep the app and widget in sync use the following settings
 
 ### Acknowledgements
 
-Thanks to [Remy Kabel](https://github.com/RomanovX) who parametrized the build and made it possible for it to be fully automated.  
+Thanks to [Remy Kabel](https://github.com/RomanovX) who parametrized the build and made it possible for it to be fully automated.
 Thanks to [Hernan Zhou](https://github.com/LuckyKat) whos [plugin](https://github.com/LuckyKat/cordova-sticker-pack-extension) was a great inspiration.

--- a/hooks/addTodayWidgetToProject.js
+++ b/hooks/addTodayWidgetToProject.js
@@ -87,6 +87,7 @@ module.exports = function (context) {
   var WIDGET_NAME = getCordovaParameter("WIDGET_NAME", contents);
   var WIDGET_BUNDLE_SUFFIX = getCordovaParameter("WIDGET_BUNDLE_SUFFIX", contents);
   var ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = getCordovaParameter("ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", contents);
+  var SWIFT_VERSION = getCordovaParameter("SWIFT_VERSION", contents);
 
   if (contents) {
     contents = contents.substring(contents.indexOf('<'));
@@ -366,7 +367,7 @@ module.exports = function (context) {
                 log('Added entitlements file reference to build settings!', 'info');
               }
               if (projectContainsSwiftFiles) {
-                buildSettingsObj['SWIFT_VERSION'] = '3.0';
+                buildSettingsObj['SWIFT_VERSION'] = SWIFT_VERSION || '3.0';
                 buildSettingsObj['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES || 'YES';
                 log('Added build settings for swift support!', 'info');
               }


### PR DESCRIPTION
The current script defaults to Swift 3.0, which is not supported by the latest versions of Xcode. In this PR I've added a `SWIFT_VERSION` config option to allow this to be set to the latest version. I've left it to default to `3.0` so it's not a breaking change, but it probably makes sense to set the default to `5` if you end up doing a new release.